### PR TITLE
removed compliance asterisk

### DIFF
--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -253,14 +253,14 @@ html(lang='en')
                     <tbody>
                         <tr>
                         <th scope="row" rowspan="1" class="table-info">Java <i class="fab fa-java"></i></th>
-                        <td>Ldproxy<sup>*</sup></td>
+                        <td>Ldproxy</td>
                         <td title="Github repository"><a href="https://github.com/interactive-instruments/ldproxy" target="_blank"><i class="fab fa-github"></i></a></td>
                         <td title="Docker image"><a href="https://hub.docker.com/r/iide/ldproxy/" target="_blank"><i class="fab fa-docker"></i></a></td>
                         <td title="Tutorial/Example"><a href="https://github.com/interactive-instruments/ldproxy/tree/master/demo/vineyards" target="_blank"><i class="fas fa-graduation-cap"></i>/<i class="fas fa-code"></i></a></td>
                         </tr>                        
                         <tr>
                         <th scope="row" rowspan="2" class="table-info">Python <i class="fab fa-python"></i></th>
-                        <td>pygeoapi<sup>*</sup></td>
+                        <td>pygeoapi</td>
                         <td title="Github repository"><a href="https://github.com/geopython/pygeoapi" target="_blank"><i class="fab fa-github"></i></a></td>
                         <td title="Docker image"><a href="https://hub.docker.com/r/geopython/pygeoapi" target="_blank"><i class="fab fa-docker"></i></a></td>
                         <td title="Tutorial/Example"><a href="https://dive.pygeoapi.io/" target="_blank"><i class="fas fa-graduation-cap"></i>/<i class="fas fa-code"></i></a></td>                
@@ -273,7 +273,7 @@ html(lang='en')
                         </tr>
                         <tr>
                         <th scope="row" rowspan="1" class="table-info">C/C++</th>
-                        <td>GNOSIS Map Server<sup>*</sup></td>
+                        <td>GNOSIS Map Server</td>
                         <td title="Website"><a href="https://ecere.ca/gnosis/" target="_blank"><i class="fas fa-link"></i></a></td>
                         <td title="Docker image"></td>
                         <td title="Tutorial/Example"></td>                


### PR DESCRIPTION
The ETS for OGC API - Tiles is not currently available, therefore there are no products that are certified as OGC Compliant to OGC API - Tiles.