### PR TITLE
Correct the link of the GDAL OGCAPI driver

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -330,7 +330,7 @@
                                 </td>
                                 <td colspan="2">
                                     Check
-                                    <a href="https://gdal.org/drivers/vector/oapif.html" target="_blank">GDAL's documentation</a>
+                                    <a href="https://gdal.org/drivers/raster/ogcapi.html" target="_blank">GDAL's documentation</a>
                                     .
                                 </td>
                             </tr>


### PR DESCRIPTION
Current link points to the GDAL OGC API Features driver